### PR TITLE
Add `state` column to Google county data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,44 +1,53 @@
 Package: covid19mobility
-Title: Fetches Data on Covid-19 Mobility Trends from Different Sources
+Title: Fetches Data on Covid-19 Mobility Trends from Different
+    Sources
 Version: 0.1.0
 Authors@R: 
-    person(given = "Jarrett",
+    c(person(given = "Jarrett",
            family = "Byrnes",
            role = c("aut", "cre"),
            email = "jarrett.byrnes@umb.edu",
-           comment = c(ORCID = "0000-0002-9791-9472"))
-Description: Scrapes trends in mobility after the Covid-19 outbreak from 
-            different sources. Currently, the package scrapes data from Google <https://www.google.com/covid19/mobility/>, 
-            Apple <https://www.apple.com/covid19/mobility>, and will add others. The data returned uses the tidy
-            Covid19R project data standard <https://covid19r.github.io/documentation/>
-            as well as the controlled vocabularies for measurement types.
+           comment = c(ORCID = "0000-0002-9791-9472")),
+    person(given = "Amanda",
+           family = "Dobbyn",
+           role = "ctb",
+           email = "amanda.e.dobbyn@gmail.com"))
+Description: Scrapes trends in mobility after the Covid-19
+    outbreak from different sources. Currently, the package scrapes data
+    from Google <https://www.google.com/covid19/mobility/>, Apple
+    <https://www.apple.com/covid19/mobility>, and will add others. The
+    data returned uses the tidy Covid19R project data standard
+    <https://covid19r.github.io/documentation/> as well as the controlled
+    vocabularies for measurement types.
 License: MIT + file LICENSE
+URL: https://github.com/Covid19R/covid19mobility
+BugReports: https://github.com/Covid19R/covid19mobility/issues
+Depends: 
+    R (>= 2.10)
+Imports: 
+    dplyr,
+    glue,
+    janitor,
+    jsonlite,
+    lubridate,
+    magrittr,
+    readr,
+    stringi,
+    tidyr,
+    tigris,
+    utils
 Suggests: 
-    testthat,
-    knitr,
-    rmarkdown,
+    gganimate,
     ggplot2,
+    knitr,
+    rgeos,
+    rmarkdown,
     rnaturalearth,
     sf,
-    gganimate,
-    rgeos
+    testthat
+VignetteBuilder: 
+    knitr
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
-Imports: 
-    jsonlite,
-    readr,
-    tidyr,
-    magrittr,
-    dplyr,
-    utils,
-    lubridate,
-    tigris,
-    stringi,
-    glue
-Depends: 
-    R (>= 2.10)
-VignetteBuilder: knitr
-URL: https://github.com/Covid19R/covid19mobility
-BugReports: https://github.com/Covid19R/covid19mobility/issues

--- a/R/globals.R
+++ b/R/globals.R
@@ -44,7 +44,7 @@ globalVariables(
     "NAME.EN",
     "old_loc",
     "country",
-    "sub-region",
+    "sub_region",
 
 
     # from google

--- a/R/refresh_covid19mobility_apple.R
+++ b/R/refresh_covid19mobility_apple.R
@@ -61,7 +61,7 @@ refresh_covid19mobility_apple_subregion <- function() {
   mob_data %>%
     dplyr::mutate(location_type = "state") %>%
     reorder_apple() %>%
-    dplyr::select(-`sub-region`)
+    dplyr::select(-sub_region)
 }
 
 #' Refresh The Apple Covid-19 Mobility Data for Cities

--- a/R/refresh_covid19mobility_apple.R
+++ b/R/refresh_covid19mobility_apple.R
@@ -28,7 +28,7 @@ refresh_covid19mobility_apple_country <- function() {
   mob_data %>%
     dplyr::mutate(location_type = "country") %>%
     reorder_apple() %>%
-    dplyr::select(-`sub-region`, -country)
+    dplyr::select(-sub_region, -country)
 }
 
 #' Refresh The Apple Covid-19 Mobility Data for Subregions
@@ -147,7 +147,8 @@ reshape_apple_mob_data <- function(mob_data) {
       data_type == "driving" ~ "driving_req_rel_volume",
       data_type == "walking" ~ "walking_req_rel_volume",
       data_type == "transit" ~ "transit_req_rel_volume"
-    ))
+    )) %>%
+    janitor::clean_names()
 }
 
 reorder_apple <- . %>%

--- a/R/refresh_covid19mobility_google.R
+++ b/R/refresh_covid19mobility_google.R
@@ -320,14 +320,20 @@ read_google_mobility <- function() {
 }
 
 covid_19_r_format <- . %>%
+  janitor::clean_names() %>%
   dplyr::select(
-    date,
-    location,
-    location_type,
-    location_code,
-    location_code_type,
-    data_type,
-    value
+    any_of(
+      c(
+        "date",
+        "location",
+        "location_type",
+        "location_code",
+        "location_code_type",
+        "state",
+        "data_type",
+        "value"
+      )
+    )
   ) %>%
   dplyr::mutate(
     data_type = gsub("_from_baseline", "", data_type),

--- a/tests/testthat/test-test_controlled_vocab.R
+++ b/tests/testthat/test-test_controlled_vocab.R
@@ -36,16 +36,35 @@ expect_contains <- function(vec1, vec2) {
 
 # OK, the testing!
 
-# the functino to run the tests
+# the function to run the tests
 
 test_one_refresh_for_vocab <- function(arow) {
+
   res <- eval(call(arow$fun))
 
   # make sure there's there there
   expect_gt(nrow(res), 0)
 
+  last_col <- 7
+
   # make sure column names are in order
-  expect_named(res[, 1:7], refresh_col_names) # allow for other cols
+  if (arow$fun == "refresh_covid19mobility_google_us_counties") {
+    refresh_col_names <-
+      c(
+        "date",
+        "location",
+        "location_type",
+        "location_code",
+        "location_code_type",
+        "state",
+        "data_type",
+        "value"
+      )
+
+    last_col <- 8
+  }
+
+  expect_named(res[, 1:last_col], refresh_col_names) # allow for other cols
 
   # loc types
   expect_contains(res$location_type, location_types)


### PR DESCRIPTION
This package is an awesome chunk of work!

The `state` column gets nixed during [this formatting](https://github.com/Covid19R/covid19mobility/compare/dev?expand=1#diff-24d8e67e937b94f47fdc2234b5f410a0R322-R337) step, so using `any_of` to allow us to keep `state` if it exists. Counties aren't super useful without the state they fall under!

Also, added `janitor` so that we can turn the ``sub-region`` (with backticks) column name to `sub_region`. If you don't want the dependency, we can do it manually instead.

Also ran `usethis::use_tidy_description` to clean up the `DESCRIPTION` a bit.
